### PR TITLE
Removing unnecessary quotes from regex

### DIFF
--- a/index.js
+++ b/index.js
@@ -18,5 +18,5 @@ module.exports = function (opts) {
 	].join('');
 
 	return opts.exact ? new RegExp('(?:^' + regex + '$)', 'i') :
-						new RegExp('(["\'])?' + regex + '\\1', 'ig');
+						new RegExp(regex, 'ig');
 };

--- a/test.js
+++ b/test.js
@@ -2,7 +2,7 @@
 var test = require('ava');
 var urlRegex = require('./');
 
-test('match URLs', function (t) {
+test('match exact URLs', function (t) {
 	var fixtures = [
 		'http://foo.com/blah_blah',
 		'http://foo.com/blah_blah/',
@@ -67,6 +67,30 @@ test('match URLs', function (t) {
 	t.end();
 });
 
+test('match URLs in text', function (t) {
+	var fixture = [
+		'Lorem ipsum //dolor.sit',
+		'<a href="http://example.com">example.com</a>',
+		'[and another](https://another.example.com)',
+		'Foo //bar.net/?q=Query with spaces'
+	].join('\n');
+
+	var expected = [
+		'//dolor.sit',
+		'http://example.com',
+		'https://another.example.com',
+		'//bar.net/?q=Query'
+	];
+
+	var actual = fixture.match(urlRegex());
+
+	expected.forEach(function (url, i) {
+		t.assert(actual[i] === url, actual[i]);
+	});
+
+	t.end();
+});
+
 test('do not match URLs', function (t) {
 	var fixtures = [
 		'http://',
@@ -112,8 +136,8 @@ test('do not match URLs', function (t) {
 	];
 
 	fixtures.forEach(function (el) {
-			t.assert(!urlRegex({exact: true}).test(el), el);
-		});
+		t.assert(!urlRegex({exact: true}).test(el), el);
+	});
 
 	t.end();
 });

--- a/test.js
+++ b/test.js
@@ -112,10 +112,8 @@ test('do not match URLs', function (t) {
 	];
 
 	fixtures.forEach(function (el) {
-		fixtures.forEach(function (el) {
 			t.assert(!urlRegex({exact: true}).test(el), el);
 		});
-	});
 
 	t.end();
 });


### PR DESCRIPTION
Quoted URLs matches are returned including the quotes:

```javascript
console.log('"http://example.com"'.match(urlRegex()));
['"http://example.com"'] // quotes are not removed
```

See [get-urls/#11](https://github.com/sindresorhus/get-urls/issues/11) for an example on why this is unwanted.

This PR addresses this.