### PR TITLE
Don't allow " in URL paths (fixes #19)

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,7 +11,7 @@ module.exports = function (opts) {
 	var domain = '(?:\\.(?:[a-z\\u00a1-\\uffff0-9]-*)*[a-z\\u00a1-\\uffff0-9]+)*';
 	var tld = '(?:\\.(?:[a-z\\u00a1-\\uffff]{2,}))';
 	var port = '(?::\\d{2,5})?';
-	var path = '(?:[/?#]\\S*)?';
+	var path = '(?:[/?#][^\\s"]*)?';
 	var regex = [
 		protocol, auth, '(?:localhost|' + ip + '|' + host + domain + tld + ')',
 		port, path

--- a/test.js
+++ b/test.js
@@ -68,6 +68,7 @@ test('match URLs in text', t => {
 	const fixture = `
 		Lorem ipsum //dolor.sit
 		<a href="http://example.com">example.com</a>
+		<a href="http://example.com/with-path">with path</a>
 		[and another](https://another.example.com) and
 		Foo //bar.net/?q=Query with spaces
 	`;
@@ -75,6 +76,7 @@ test('match URLs in text', t => {
 	const expected = [
 		'//dolor.sit',
 		'http://example.com',
+		'http://example.com/with-path',
 		'https://another.example.com',
 		'//bar.net/?q=Query'
 	];

--- a/test.js
+++ b/test.js
@@ -65,12 +65,12 @@ test('match exact URLs', t => {
 });
 
 test('match URLs in text', t => {
-	const fixture = [
-		'Lorem ipsum //dolor.sit',
-		'<a href="http://example.com">example.com</a>',
-		'[and another](https://another.example.com)',
-		'Foo //bar.net/?q=Query with spaces'
-	].join('\n');
+	const fixture = `
+		Lorem ipsum //dolor.sit
+		<a href="http://example.com">example.com</a>
+		[and another](https://another.example.com) and
+		Foo //bar.net/?q=Query with spaces
+	`;
 
 	const expected = [
 		'//dolor.sit',
@@ -81,7 +81,7 @@ test('match URLs in text', t => {
 
 	const actual = fixture.match(fn());
 
-	expected.forEach((url, i) => t.is(actual[i], url));
+	t.same(actual, expected);
 });
 
 test('do not match URLs', t => {


### PR DESCRIPTION
An unencoded `"` is not allowed in an URL so this PR excludes that character from the URL path regex to address #19.