### PR TITLE
allow a dot (.) at the end of hostnames

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,7 +9,7 @@ module.exports = function (opts) {
 	var ip = ipRegex.v4().source;
 	var host = '(?:(?:[a-z\\u00a1-\\uffff0-9]-*)*[a-z\\u00a1-\\uffff0-9]+)';
 	var domain = '(?:\\.(?:[a-z\\u00a1-\\uffff0-9]-*)*[a-z\\u00a1-\\uffff0-9]+)*';
-	var tld = '(?:\\.(?:[a-z\\u00a1-\\uffff]{2,}))';
+	var tld = '(?:\\.(?:[a-z\\u00a1-\\uffff]{2,}))\\.?';
 	var port = '(?::\\d{2,5})?';
 	var path = '(?:[/?#][^\\s"]*)?';
 	var regex = [
@@ -17,6 +17,5 @@ module.exports = function (opts) {
 		port, path
 	].join('');
 
-	return opts.exact ? new RegExp('(?:^' + regex + '$)', 'i') :
-						new RegExp(regex, 'ig');
+	return opts.exact ? new RegExp('(?:^' + regex + '$)', 'i') : new RegExp(regex, 'ig');
 };

--- a/test.js
+++ b/test.js
@@ -3,6 +3,7 @@ import fn from './';
 
 test('match exact URLs', t => {
 	const fixtures = [
+		'http://example.com.',
 		'http://foo.com/blah_blah',
 		'http://foo.com/blah_blah/',
 		'http://foo.com/blah_blah_(wikipedia)',
@@ -115,7 +116,6 @@ test('do not match URLs', t => {
 		'http://123.123.123',
 		'http://3628126748',
 		'http://.www.foo.bar/',
-		'http://www.foo.bar./',
 		'http://.www.foo.bar./',
 		'http://go/ogle.com',
 		'http://foo.bar/ /',


### PR DESCRIPTION
Updated per Diego Perini's gist that now allows a dot at the end of a hostname: See: https://gist.github.com/dperini/729294#file-regex-weburl-js-L54