### PR TITLE
Update path regex to not accept closing parens

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,7 +11,7 @@ module.exports = opts => {
 	const domain = '(?:\\.(?:[a-z\\u00a1-\\uffff0-9]-*)*[a-z\\u00a1-\\uffff0-9]+)*';
 	const tld = '(?:\\.(?:[a-z\\u00a1-\\uffff]{2,}))\\.?';
 	const port = '(?::\\d{2,5})?';
-	const path = '(?:[/?#][^\\s"]*)?';
+	const path = '(?:[/?#][^\\s"\\)]*)?';
 	const regex = `(?:${protocol}|www\\.)${auth}(?:localhost|${ip}|${host}${domain}${tld})${port}${path}`;
 
 	return opts.exact ? new RegExp(`(?:^${regex}$)`, 'i') : new RegExp(regex, 'ig');


### PR DESCRIPTION
This fixes a few cases, one of which is documented in #34:
* css url's of the format `background-image:url(http://example.com/img.jpg);`
* markdown url's such as `look at [my image](http://example.com/img.jpg) blah blah`