### PR TITLE
Replace ES6 features with ES5 for browser and tool compatibility

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 'use strict';
 const ipRegex = require('ip-regex');
 
-module.exports = opts => {
+module.exports = function(opts) {
 	opts = opts || {};
 
 	const protocol = '(?:(?:[a-z]+:)?//)';
@@ -12,7 +12,11 @@ module.exports = opts => {
 	const tld = '(?:\\.(?:[a-z\\u00a1-\\uffff]{2,}))\\.?';
 	const port = '(?::\\d{2,5})?';
 	const path = '(?:[/?#][^\\s"]*)?';
-	const regex = `(?:${protocol}|www\\.)${auth}(?:localhost|${ip}|${host}${domain}${tld})${port}${path}`;
+	const regex = '(?:' + protocol + '|www\\.)' + auth +
+		'(?:localhost|' + ip + '|' + host + domain + tld + ')' +
+		port + path;
 
-	return opts.exact ? new RegExp(`(?:^${regex}$)`, 'i') : new RegExp(regex, 'ig');
+	return opts.exact ?
+		new RegExp('(?:^' + regex + '$)', 'i') : 
+		new RegExp(regex, 'ig');
 };

--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 'use strict';
 const ipRegex = require('ip-regex');
 
-module.exports = function(opts) {
+module.exports = function (opts) {
 	opts = opts || {};
 
 	const protocol = '(?:(?:[a-z]+:)?//)';
@@ -17,6 +17,5 @@ module.exports = function(opts) {
 		port + path;
 
 	return opts.exact ?
-		new RegExp('(?:^' + regex + '$)', 'i') : 
-		new RegExp(regex, 'ig');
+		new RegExp('(?:^' + regex + '$)', 'i') : new RegExp(regex, 'ig');
 };


### PR DESCRIPTION
Because many browsers and other tools still don't fully support ES6 yet, the code for most NPM libraries is still in ES5 (even if the sources are in ES6).  

I ran into a painful situation building my application, [Tad](https://github.com/antonycourtney/tad), which depends on url-regex, because Tad is built with webpack, which in turn uses UglifyJS.  UglifyJS currently only supports ES5.

Most libraries written in ES6 are run through a transpiler like Babel first to produce ES5 code for NPM. I considered doing that, but the extra machinery and build tooling would be overkill here, so I simply manually translated the code to ES5.