### PR TITLE
Extract heavy non-strict version

### DIFF
--- a/base.js
+++ b/base.js
@@ -1,0 +1,18 @@
+'use strict';
+const ipRegex = require('ip-regex');
+
+module.exports = (opts, tlds) => {
+	opts = Object.assign({}, opts);
+
+	const protocol = `(?:(?:[a-z]+:)?//)${tlds ? '?' : ''}`;
+	const auth = '(?:\\S+(?::\\S*)?@)?';
+	const ip = ipRegex.v4().source;
+	const host = '(?:(?:[a-z\\u00a1-\\uffff0-9]-*)*[a-z\\u00a1-\\uffff0-9]+)';
+	const domain = '(?:\\.(?:[a-z\\u00a1-\\uffff0-9]-*)*[a-z\\u00a1-\\uffff0-9]+)*';
+	const tld = `(?:\\.(?:${tlds || '[a-z\\u00a1-\\uffff]{2,}'}))\\.?`;
+	const port = '(?::\\d{2,5})?';
+	const path = '(?:[/?#][^\\s"]*)?';
+	const regex = `(?:${protocol}|www\\.)${auth}(?:localhost|${ip}|${host}${domain}${tld})${port}${path}`;
+
+	return opts.exact ? new RegExp(`(?:^${regex}$)`, 'i') : new RegExp(regex, 'ig');
+};

--- a/index.js
+++ b/index.js
@@ -1,19 +1,5 @@
-'use strict';
-const ipRegex = require('ip-regex');
-const tlds = require('tlds');
+const buildRegex = require('./base');
 
-module.exports = opts => {
-	opts = Object.assign({strict: true}, opts);
-
-	const protocol = `(?:(?:[a-z]+:)?//)${opts.strict ? '' : '?'}`;
-	const auth = '(?:\\S+(?::\\S*)?@)?';
-	const ip = ipRegex.v4().source;
-	const host = '(?:(?:[a-z\\u00a1-\\uffff0-9]-*)*[a-z\\u00a1-\\uffff0-9]+)';
-	const domain = '(?:\\.(?:[a-z\\u00a1-\\uffff0-9]-*)*[a-z\\u00a1-\\uffff0-9]+)*';
-	const tld = `(?:\\.${opts.strict ? '(?:[a-z\\u00a1-\\uffff]{2,})' : `(?:${tlds.join('|')})`})\\.?`;
-	const port = '(?::\\d{2,5})?';
-	const path = '(?:[/?#][^\\s"]*)?';
-	const regex = `(?:${protocol}|www\\.)${auth}(?:localhost|${ip}|${host}${domain}${tld})${port}${path}`;
-
-	return opts.exact ? new RegExp(`(?:^${regex}$)`, 'i') : new RegExp(regex, 'ig');
-};
+// This needs to be called this way because
+// buildRegex accepts a second parameter, while `url-regex` doesn't
+module.exports = opts => buildRegex(opts);

--- a/non-strict.js
+++ b/non-strict.js
@@ -1,0 +1,4 @@
+const tlds = require('tlds');
+const buildRegex = require('./base');
+
+module.exports = opts => buildRegex(opts, tlds.join('|'));

--- a/readme.md
+++ b/readme.md
@@ -29,14 +29,21 @@ urlRegex({exact: true}).test('http://github.com foo bar');
 urlRegex({exact: true}).test('http://github.com');
 //=> true
 
-urlRegex({strict: false}).test('github.com foo bar');
-//=> true
-
-urlRegex({exact: true, strict: false}).test('github.com');
-//=> true
-
 'foo http://github.com bar //google.com'.match(urlRegex());
 //=> ['http://github.com', '//google.com']
+```
+
+`url-regex` forces URLs to start with a valid protocol or `www`.
+
+`url-regex/non-strict` doesn't have this restriction. It'll also match the TLD against a list of valid [TLDs](https://github.com/stephenmathieson/node-tlds).
+
+```js
+const nonStrictUrlRegex = require('url-regex/non-strict');
+nonStrictUrlRegex().test('github.com foo bar');
+//=> true
+
+nonStrictUrlRegex({exact: true}).test('github.com');
+//=> true
 ```
 
 
@@ -54,14 +61,6 @@ Type: `boolean`<br>
 Default: `false`
 
 Only match an exact string. Useful with `RegExp#test` to check if a string is a URL.
-
-##### strict
-
-Type: `boolean`<br>
-Default: `true`
-
-Force URLs to start with a valid protocol or `www`. If set to `false` it'll match the TLD against a list of valid [TLDs](https://github.com/stephenmathieson/node-tlds).
-
 
 ## Related
 

--- a/test.js
+++ b/test.js
@@ -1,5 +1,6 @@
 import test from 'ava';
-import m from './';
+import nonStrict from './non-strict';
+import strict from './';
 
 test('match exact URLs', t => {
 	const fixtures = [
@@ -63,7 +64,7 @@ test('match exact URLs', t => {
 	];
 
 	for (const x of fixtures) {
-		t.true(m({exact: true}).test(x));
+		t.true(strict({exact: true}).test(x));
 	}
 });
 
@@ -82,7 +83,7 @@ test('match URLs in text', t => {
 		'http://example.com/with-path',
 		'https://another.example.com',
 		'//bar.net/?q=Query'
-	], fixture.match(m()));
+	], fixture.match(strict()));
 });
 
 test('do not match URLs', t => {
@@ -129,7 +130,7 @@ test('do not match URLs', t => {
 	];
 
 	for (const x of fixtures) {
-		t.false(m({exact: true}).test(x));
+		t.false(strict({exact: true}).test(x));
 	}
 });
 
@@ -192,6 +193,6 @@ test('match using list of TLDs', t => {
 	];
 
 	for (const x of fixtures) {
-		t.true(m({exact: true, strict: false}).test(x));
+		t.true(nonStrict({exact: true}).test(x));
 	}
 });


### PR DESCRIPTION
```sh
❯ browserify index.js | babili | gzip-size
751 B

❯ browserify non-strict.js | babili | gzip-size
6.72 kB
```
Closes #39 