### PR TITLE
Add `local` option.

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,16 +5,15 @@ const tlds = require('tlds');
 module.exports = opts => {
 	opts = Object.assign({strict: true, local: false}, opts);
 
-	const protocol = `(?:(?:[a-z]+:)?//)${opts.strict ? '' : '?'}`;
+	const protocol = '(?:(?:[a-z]+:)?//)';
 	const auth = '(?:\\S+(?::\\S*)?@)?';
 	const ip = ipRegex.v4().source;
 	const host = '(?:(?:[a-z\\u00a1-\\uffff0-9]-*)*[a-z\\u00a1-\\uffff0-9]+)';
 	const domain = '(?:\\.(?:[a-z\\u00a1-\\uffff0-9]-*)*[a-z\\u00a1-\\uffff0-9]+)*';
 	const tld = `(?:\\.${opts.strict ? '(?:[a-z\\u00a1-\\uffff]{2,})' : `(?:${tlds.sort((a, b) => b.length - a.length).join('|')})`})\\.?`;
-	const locals = opts.local ? host : 'localhost';
 	const port = '(?::\\d{2,5})?';
 	const path = '(?:[/?#][^\\s"]*)?';
-	const regex = `(?:${protocol}|www\\.)${auth}(?:${locals}|${ip}|${host}${domain}${tld})${port}${path}`;
+	const regex = `(?:(?:${protocol}${opts.strict ? '' : '?'}|www\\.)${auth}(?:localhost|${ip}|${host}${domain}${tld})${opts.local ? `|${protocol}${host}` : ''})${port}${path}`;
 
 	return opts.exact ? new RegExp(`(?:^${regex}$)`, 'i') : new RegExp(regex, 'ig');
 };

--- a/index.js
+++ b/index.js
@@ -3,7 +3,7 @@ const ipRegex = require('ip-regex');
 const tlds = require('tlds');
 
 module.exports = opts => {
-	opts = Object.assign({strict: true}, opts);
+	opts = Object.assign({strict: true, local: false}, opts);
 
 	const protocol = `(?:(?:[a-z]+:)?//)${opts.strict ? '' : '?'}`;
 	const auth = '(?:\\S+(?::\\S*)?@)?';
@@ -11,9 +11,10 @@ module.exports = opts => {
 	const host = '(?:(?:[a-z\\u00a1-\\uffff0-9]-*)*[a-z\\u00a1-\\uffff0-9]+)';
 	const domain = '(?:\\.(?:[a-z\\u00a1-\\uffff0-9]-*)*[a-z\\u00a1-\\uffff0-9]+)*';
 	const tld = `(?:\\.${opts.strict ? '(?:[a-z\\u00a1-\\uffff]{2,})' : `(?:${tlds.sort((a, b) => b.length - a.length).join('|')})`})\\.?`;
+	const locals = opts.local ? host : 'localhost';
 	const port = '(?::\\d{2,5})?';
 	const path = '(?:[/?#][^\\s"]*)?';
-	const regex = `(?:${protocol}|www\\.)${auth}(?:localhost|${ip}|${host}${domain}${tld})${port}${path}`;
+	const regex = `(?:${protocol}|www\\.)${auth}(?:${locals}|${ip}|${host}${domain}${tld})${port}${path}`;
 
 	return opts.exact ? new RegExp(`(?:^${regex}$)`, 'i') : new RegExp(regex, 'ig');
 };

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "url-regex-local",
-  "version": "1.0.0",
-  "description": "Regular expression for matching URLs, forked & extended version",
+  "version": "1.0.1",
+  "description": "Regular expression for matching URLs, forked & extended version with local URL matching",
   "license": "MIT",
   "repository": "samotlark/url-regex",
   "author": {

--- a/package.json
+++ b/package.json
@@ -1,13 +1,12 @@
 {
-  "name": "url-regex",
-  "version": "4.1.1",
-  "description": "Regular expression for matching URLs",
+  "name": "url-regex-local",
+  "version": "1.0.0",
+  "description": "Regular expression for matching URLs, forked & extended version",
   "license": "MIT",
-  "repository": "kevva/url-regex",
+  "repository": "samotlark/url-regex",
   "author": {
-    "name": "Kevin Mårtensson",
-    "email": "kevinmartensson@gmail.com",
-    "url": "https://github.com/kevva"
+    "name": "Tomáš Král",
+    "url": "https://github.com/samotlark"
   },
   "engines": {
     "node": ">=4"

--- a/readme.md
+++ b/readme.md
@@ -29,6 +29,9 @@ urlRegex({exact: true}).test('http://github.com foo bar');
 urlRegex({exact: true}).test('http://github.com');
 //=> true
 
+urlRegex({exact: true, local: true}).test('http://orgchart/index.php');
+//=> true
+
 urlRegex({strict: false}).test('github.com foo bar');
 //=> true
 
@@ -61,6 +64,13 @@ Type: `boolean`<br>
 Default: `true`
 
 Force URLs to start with a valid protocol or `www`. If set to `false` it'll match the TLD against a list of valid [TLDs](https://github.com/stephenmathieson/node-tlds).
+
+##### local
+
+Type: `boolean`<br>
+Default: `false`
+
+Allow also to test URLs with private network hosts. If set to `true` it'll match local URLs like `http://forge/library/home/` (without TLD).
 
 
 ## Related

--- a/readme.md
+++ b/readme.md
@@ -1,4 +1,4 @@
-# url-regex [![Build Status](http://img.shields.io/travis/kevva/url-regex.svg?style=flat)](https://travis-ci.org/kevva/url-regex)
+# url-regex-local
 
 > Regular expression for matching URLs
 
@@ -8,7 +8,7 @@ Based on this [gist](https://gist.github.com/dperini/729294) by Diego Perini.
 ## Install
 
 ```
-$ npm install --save url-regex
+$ npm install --save url-regex-local
 ```
 
 

--- a/test.js
+++ b/test.js
@@ -215,3 +215,25 @@ test('should not match local domains but localhost', t => {
 		t.false(m({exact: true}).test(x));
 	}
 });
+
+test('should not match words or text as local URLs', t => {
+	const fixtures = [
+		'text',
+		'text with more words, but still without URLs',
+		'text without url and/or slash'
+	];
+
+	for (const x of fixtures) {
+		t.false(m({strict: false, exact: false, local: true}).test(x));
+	}
+});
+
+test('match local URLs in text', t => {
+	const fixtures = [
+		'text with local(http://orgchart/index.php) urls'
+	];
+
+	for (const x of fixtures) {
+		t.true(m({strict: false, exact: false, local: true}).test(x));
+	}
+});

--- a/test.js
+++ b/test.js
@@ -1,5 +1,5 @@
 import test from 'ava';
-import m from './';
+import m from './index';
 
 test('match exact URLs', t => {
 	const fixtures = [
@@ -193,5 +193,25 @@ test('match using list of TLDs', t => {
 
 	for (const x of fixtures) {
 		t.true(m({exact: true, strict: false}).test(x));
+	}
+});
+
+const localUrlFixtures = [
+	'http://orgchart/index.php',
+	'http://aplicakcepredpisy/index.php?tpl=pk_khika$book_id=1057',
+	'http://forge/library/home/'
+];
+
+test('match local URLs', t => {
+	for (const x of localUrlFixtures) {
+		t.true(m({exact: true, local: true}).test(x));
+	}
+});
+
+test('should not match local domains but localhost', t => {
+	t.true(m({exact: true}).test('http://localhost/'));
+
+	for (const x of localUrlFixtures) {
+		t.false(m({exact: true}).test(x));
 	}
 });


### PR DESCRIPTION
With `local` option, it will match private network hosts in URL, e.g. `http://forge/library/home/`. Default value is `false`, so it won't change behavior of the library unless someone explicitly use it.