### PR TITLE
Don't allow ' in path

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,7 +12,7 @@ module.exports = opts => {
 	const domain = '(?:\\.(?:[a-z\\u00a1-\\uffff0-9]-*)*[a-z\\u00a1-\\uffff0-9]+)*';
 	const tld = `(?:\\.${opts.strict ? '(?:[a-z\\u00a1-\\uffff]{2,})' : `(?:${tlds.sort((a, b) => b.length - a.length).join('|')})`})\\.?`;
 	const port = '(?::\\d{2,5})?';
-	const path = '(?:[/?#][^\\s"]*)?';
+	const path = '(?:[/?#][^\\s"\']*)?';
 	const regex = `(?:${protocol}|www\\.)${auth}(?:localhost|${ip}|${host}${domain}${tld})${port}${path}`;
 
 	return opts.exact ? new RegExp(`(?:^${regex}$)`, 'i') : new RegExp(regex, 'ig');

--- a/test.js
+++ b/test.js
@@ -73,7 +73,8 @@ test('match URLs in text', t => {
 		<a href="http://example.com">example.com</a>
 		<a href="http://example.com/with-path">with path</a>
 		[and another](https://another.example.com) and
-		Foo //bar.net/?q=Query with spaces
+		Foo //bar.net/?q=Query with spaces,license/
+		background: url('http://example.com/pic.jpg'); height: 100px;
 	`;
 
 	t.deepEqual([
@@ -81,7 +82,8 @@ test('match URLs in text', t => {
 		'http://example.com',
 		'http://example.com/with-path',
 		'https://another.example.com',
-		'//bar.net/?q=Query'
+		'//bar.net/?q=Query',
+		'http://example.com/pic.jpg'
 	], fixture.match(m()));
 });
 


### PR DESCRIPTION
failing test case: `background: url('http://example.com/pic.jpg');`
resulted in `http://example.com/pic.jpg'`

fixed #54