### PR TITLE
Add option to disable matching urls with http basic authentication

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -13,6 +13,13 @@ declare namespace urlRegex {
 		@default true
 		*/
 		readonly strict?: boolean;
+
+		/**
+		Enable/disable match on [Basic HTTP Authentication Scheme](https://developer.mozilla.org/en-US/docs/Web/HTTP/Authentication#Basic_authentication_scheme)
+
+		@default true
+		*/
+		readonly auth?: boolean;
 	}
 }
 
@@ -40,6 +47,12 @@ urlRegex({strict: false}).test('github.com foo bar');
 
 urlRegex({exact: true, strict: false}).test('github.com');
 //=> true
+
+urlRegex({exact: true}).test('user@github.com');
+//=> true
+
+urlRegex({exact: true, auth: false}).test('user@github.com');
+//=> false
 
 'foo http://github.com bar //google.com'.match(urlRegex());
 //=> ['http://github.com', '//google.com']

--- a/index.js
+++ b/index.js
@@ -4,12 +4,13 @@ const tlds = require('tlds');
 
 module.exports = options => {
 	options = {
+		auth: true,
 		strict: true,
 		...options
 	};
 
 	const protocol = `(?:(?:[a-z]+:)?//)${options.strict ? '' : '?'}`;
-	const auth = '(?:\\S+(?::\\S*)?@)?';
+	const auth = options.auth ? '(?:\\S+(?::\\S*)?@)?' : '';
 	const ip = ipRegex.v4().source;
 	const host = '(?:(?:[a-z\\u00a1-\\uffff0-9][-_]*)*[a-z\\u00a1-\\uffff0-9]+)';
 	const domain = '(?:\\.(?:[a-z\\u00a1-\\uffff0-9]-*)*[a-z\\u00a1-\\uffff0-9]+)*';

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -4,3 +4,4 @@ import urlRegex = require('.');
 expectType<RegExp>(urlRegex());
 expectType<RegExp>(urlRegex({exact: true}));
 expectType<RegExp>(urlRegex({strict: false}));
+expectType<RegExp>(urlRegex({auth: false}));


### PR DESCRIPTION
Fixes #51 by adding an option to disable the HTTP Basic Authentication regex that matches on emails.

It's worth noting that without the `exact` option the regex will match:
`user@github.com` -> `github.com`
`http://user@github.com` -> `github.com`

I'm not familiar enough with regex to thinker with the pattern to make it reject urls with @ in it.