### PR TITLE
Don't use arrow functions and const to work on IE11

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,15 +8,15 @@ module.exports = function(options) {
 		...options
 	};
 
-	const protocol = `(?:(?:[a-z]+:)?//)${options.strict ? '' : '?'}`;
-	const auth = '(?:\\S+(?::\\S*)?@)?';
-	const ip = ipRegex.v4().source;
-	const host = '(?:(?:[a-z\\u00a1-\\uffff0-9][-_]*)*[a-z\\u00a1-\\uffff0-9]+)';
-	const domain = '(?:\\.(?:[a-z\\u00a1-\\uffff0-9]-*)*[a-z\\u00a1-\\uffff0-9]+)*';
-	const tld = `(?:\\.${options.strict ? '(?:[a-z\\u00a1-\\uffff]{2,})' : `(?:${tlds.sort(function (a, b) { return b.length - a.length; }).join('|')})`})\\.?`;
-	const port = '(?::\\d{2,5})?';
-	const path = '(?:[/?#][^\\s"]*)?';
-	const regex = `(?:${protocol}|www\\.)${auth}(?:localhost|${ip}|${host}${domain}${tld})${port}${path}`;
+	var protocol = `(?:(?:[a-z]+:)?//)${options.strict ? '' : '?'}`;
+	var auth = '(?:\\S+(?::\\S*)?@)?';
+	var ip = ipRegex.v4().source;
+	var host = '(?:(?:[a-z\\u00a1-\\uffff0-9][-_]*)*[a-z\\u00a1-\\uffff0-9]+)';
+	var domain = '(?:\\.(?:[a-z\\u00a1-\\uffff0-9]-*)*[a-z\\u00a1-\\uffff0-9]+)*';
+	var tld = `(?:\\.${options.strict ? '(?:[a-z\\u00a1-\\uffff]{2,})' : `(?:${tlds.sort(function (a, b) { return b.length - a.length; }).join('|')})`})\\.?`;
+	var port = '(?::\\d{2,5})?';
+	var path = '(?:[/?#][^\\s"]*)?';
+	var regex = `(?:${protocol}|www\\.)${auth}(?:localhost|${ip}|${host}${domain}${tld})${port}${path}`;
 
 	return options.exact ? new RegExp(`(?:^${regex}$)`, 'i') : new RegExp(regex, 'ig');
 };

--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@
 const ipRegex = require('ip-regex');
 const tlds = require('tlds');
 
-module.exports = options => {
+module.exports = function(options) {
 	options = {
 		strict: true,
 		...options
@@ -13,7 +13,7 @@ module.exports = options => {
 	const ip = ipRegex.v4().source;
 	const host = '(?:(?:[a-z\\u00a1-\\uffff0-9][-_]*)*[a-z\\u00a1-\\uffff0-9]+)';
 	const domain = '(?:\\.(?:[a-z\\u00a1-\\uffff0-9]-*)*[a-z\\u00a1-\\uffff0-9]+)*';
-	const tld = `(?:\\.${options.strict ? '(?:[a-z\\u00a1-\\uffff]{2,})' : `(?:${tlds.sort((a, b) => b.length - a.length).join('|')})`})\\.?`;
+	const tld = `(?:\\.${options.strict ? '(?:[a-z\\u00a1-\\uffff]{2,})' : `(?:${tlds.sort(function (a, b) { return b.length - a.length; }).join('|')})`})\\.?`;
 	const port = '(?::\\d{2,5})?';
 	const path = '(?:[/?#][^\\s"]*)?';
 	const regex = `(?:${protocol}|www\\.)${auth}(?:localhost|${ip}|${host}${domain}${tld})${port}${path}`;


### PR DESCRIPTION
The library cannot be used out-of-the-box on IE11 because IE6 is not supported there.

This PR simply convert the two arrow functions into classic `function`s and replace `const` by `var` 