### PR TITLE
[VULNERABILITY] Parsing a long String will result in 100% CPU usage and `String.test` will never finish

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,7 @@
 'use strict';
 const ipRegex = require('ip-regex');
 const tlds = require('tlds');
+const RE2 = require('re2');
 
 module.exports = options => {
 	options = {
@@ -18,5 +19,5 @@ module.exports = options => {
 	const path = '(?:[/?#][^\\s"]*)?';
 	const regex = `(?:${protocol}|www\\.)${auth}(?:localhost|${ip}|${host}${domain}${tld})${port}${path}`;
 
-	return options.exact ? new RegExp(`(?:^${regex}$)`, 'i') : new RegExp(regex, 'ig');
+	return options.exact ? new RE2(`(?:^${regex}$)`, 'i') : new RE2(regex, 'ig');
 };

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
 	],
 	"dependencies": {
 		"ip-regex": "^4.1.0",
+		"re2": "^1.15.4",
 		"tlds": "^1.203.0"
 	},
 	"devDependencies": {

--- a/test.js
+++ b/test.js
@@ -136,6 +136,15 @@ test('do not match URLs', t => {
 	}
 });
 
+test('do not match URLs with non-strict mode', t => {
+	const fixtures = [
+		'018137.113.215.4074.138.129.172220.179.206.94180.213.144.175250.45.147.1364868726sgdm6nohQ'
+	];
+	for (const x of fixtures) {
+		t.false(urlRegex({exact: true, strict: false}).test(x));
+	}
+});
+
 test('match using list of TLDs', t => {
 	const fixtures = [
 		'foo.com/blah_blah',


### PR DESCRIPTION
As @niftylettuce mentioned in https://github.com/kevva/url-regex/issues/70
This PR update to use `node-re2` to fix a very long string can cause a Denial of Service.